### PR TITLE
Initialize Nuxt3 project with lint tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "Vue.volar"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# bookshelf
+# Bookshelf
+
+This is a sample Nuxt 3 project for managing personal books.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Linting
+
+This project uses ESLint's flat configuration.
+
+```bash
+npm run lint
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import tseslint from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+import vue from 'eslint-plugin-vue'
+import nuxt from 'eslint-plugin-nuxt'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    files: ['**/*.{ts,vue}'],
+    ignores: ['node_modules', '.output'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module'
+      }
+    },
+    plugins: {
+      vue,
+      nuxt,
+      '@typescript-eslint': tseslint
+    },
+    rules: {
+      ...vue.configs['vue3-recommended'].rules,
+      ...nuxt.configs['flat/recommended'].rules,
+      ...tseslint.configs.recommended.rules
+    }
+  },
+  ...prettier
+]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,8 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  devtools: { enabled: true },
+  typescript: {
+    strict: true
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bookshelf",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs",
+    "lint": "eslint . --ext .ts,.vue"
+  },
+  "dependencies": {
+    "nuxt": "^3.11.0"
+  },
+  "devDependencies": {
+    "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "eslint": "^8.55.0",
+    "eslint-plugin-vue": "^9.18.0",
+    "eslint-plugin-nuxt": "^4.0.0",
+    "prettier": "^3.2.5"
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+const message = 'Welcome to the Bookshelf'
+</script>
+
+<template>
+  <div class="container">
+    <h1>{{ message }}</h1>
+  </div>
+</template>
+
+<style scoped>
+.container {
+  padding: 2rem;
+}
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "types": ["@types/node"],
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up Nuxt 3 starter project
- add ESLint/Prettier configuration
- configure VS Code recommended extensions and settings
- add EditorConfig
- update README with usage instructions
- switch ESLint to flat config

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684ceb35a524832fa94ed62a6dad4bc6