### PR TITLE
Fix ESLint ignore directories

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import prettier from 'eslint-config-prettier'
 export default [
   {
     files: ['**/*.{ts,vue}'],
-    ignores: ['node_modules', '.output'],
+    ignores: ['node_modules', '.output', '.nuxt'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {


### PR DESCRIPTION
## Summary
- ignore `.nuxt` directory in the ESLint flat config

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684d534cdae0832f90602819dfb30ab4