### PR TITLE
Setup devcontainer with Node 20

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,7 @@
+# Dev Container
+
+This configuration sets up a development environment with Node.js 20 for working on the Bookshelf project.
+
+The container installs project dependencies after creation and exposes port `3000` for the Nuxt dev server.
+
+Useful VS Code extensions are pre-installed, including ESLint and Volar.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Bookshelf DevContainer",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Nuxt"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "eslint.experimental.useFlatConfig": true
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "Vue.volar",
+        "Vue.vscode-typescript-vue-plugin"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Dev Container configuration with Node.js 20
- include VS Code extension defaults
- document container usage

## Testing
- `npm run lint -- --fix`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871120c9b28832fabe677e7bd20005a