### PR TITLE
Add library UI and extra sample books

### DIFF
--- a/components/BookCard.vue
+++ b/components/BookCard.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-interface Book {
-  id: number;
-  title: string;
-  author: string;
-  genre: string;
-  cover: string;
-}
+import type { Book } from '~/data/books';
 
 defineProps<{ book: Book }>();
 </script>

--- a/data/books.ts
+++ b/data/books.ts
@@ -1,0 +1,80 @@
+export interface Book {
+  id: number;
+  title: string;
+  author: string;
+  genre: string;
+  cover: string;
+}
+
+export const sampleBooks: Book[] = [
+  {
+    id: 1,
+    title: '1984',
+    author: 'George Orwell',
+    genre: 'Dystopian',
+    cover: 'https://placehold.co/150x200?text=1984',
+  },
+  {
+    id: 2,
+    title: 'The Great Gatsby',
+    author: 'F. Scott Fitzgerald',
+    genre: 'Classic',
+    cover: 'https://placehold.co/150x200?text=Gatsby',
+  },
+  {
+    id: 3,
+    title: 'Brave New World',
+    author: 'Aldous Huxley',
+    genre: 'Dystopian',
+    cover: 'https://placehold.co/150x200?text=Brave',
+  },
+  {
+    id: 4,
+    title: 'Moby Dick',
+    author: 'Herman Melville',
+    genre: 'Adventure',
+    cover: 'https://placehold.co/150x200?text=Moby',
+  },
+  {
+    id: 5,
+    title: 'To Kill a Mockingbird',
+    author: 'Harper Lee',
+    genre: 'Classic',
+    cover: 'https://placehold.co/150x200?text=Mockingbird',
+  },
+  {
+    id: 6,
+    title: 'The Catcher in the Rye',
+    author: 'J.D. Salinger',
+    genre: 'Fiction',
+    cover: 'https://placehold.co/150x200?text=Catcher',
+  },
+  {
+    id: 7,
+    title: 'Pride and Prejudice',
+    author: 'Jane Austen',
+    genre: 'Classic',
+    cover: 'https://placehold.co/150x200?text=Pride',
+  },
+  {
+    id: 8,
+    title: 'The Hobbit',
+    author: 'J.R.R. Tolkien',
+    genre: 'Fantasy',
+    cover: 'https://placehold.co/150x200?text=Hobbit',
+  },
+  {
+    id: 9,
+    title: 'Fahrenheit 451',
+    author: 'Ray Bradbury',
+    genre: 'Dystopian',
+    cover: 'https://placehold.co/150x200?text=F451',
+  },
+  {
+    id: 10,
+    title: 'War and Peace',
+    author: 'Leo Tolstoy',
+    genre: 'Historical',
+    cover: 'https://placehold.co/150x200?text=WarPeace',
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "start": "node .output/server/index.mjs",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "type-check": "nuxi typecheck",
+    "test": "vitest run"
   },
   "dependencies": {
     "@nuxt/eslint": "^1.4.1",
@@ -17,13 +19,16 @@
     "@nuxt/devtools": "^2.5.0",
     "@nuxt/test-utils": "^3.19.1",
     "@types/node": "^24.0.1",
+    "@vitejs/plugin-vue": "^6.0.0",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.0.0",
     "eslint-plugin-format": "^1.0.1",
+    "jsdom": "^26.1.0",
     "jsonc-eslint-parser": "^2.4.0",
     "prettier": "^3.2.5",
     "taze": "^19.1.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vue-tsc": "^3.0.1"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,42 +1,8 @@
 <script setup lang="ts">
-interface Book {
-  id: number;
-  title: string;
-  author: string;
-  genre: string;
-  cover: string;
-}
+import type { Book } from '~/data/books';
+import { sampleBooks } from '~/data/books';
 
-const books = ref<Book[]>([
-  {
-    id: 1,
-    title: '1984',
-    author: 'George Orwell',
-    genre: 'Dystopian',
-    cover: 'https://placehold.co/150x200?text=1984',
-  },
-  {
-    id: 2,
-    title: 'The Great Gatsby',
-    author: 'F. Scott Fitzgerald',
-    genre: 'Classic',
-    cover: 'https://placehold.co/150x200?text=Gatsby',
-  },
-  {
-    id: 3,
-    title: 'Brave New World',
-    author: 'Aldous Huxley',
-    genre: 'Dystopian',
-    cover: 'https://placehold.co/150x200?text=Brave',
-  },
-  {
-    id: 4,
-    title: 'Moby Dick',
-    author: 'Herman Melville',
-    genre: 'Adventure',
-    cover: 'https://placehold.co/150x200?text=Moby',
-  },
-]);
+const books = ref<Book[]>(sampleBooks);
 
 const searchQuery = ref('');
 const selectedGenre = ref('');
@@ -68,49 +34,67 @@ const sortedBooks = computed(() => {
 </script>
 
 <template>
-  <div class="p-8">
-    <h1>Bookshelf</h1>
+  <div
+    class="min-h-screen bg-cover bg-center"
+    style="background-image: url('https://images.unsplash.com/photo-1524985069026-dd778a71c7b4?auto=format&fit=crop&w=1350&q=80')"
+  >
+    <div class="p-8 min-h-screen bg-white/70 bookshelf">
+      <h1>Bookshelf</h1>
 
-    <div class="flex gap-4 mb-4">
-      <input
-        v-model="searchQuery"
-        placeholder="Search by title or author"
-        class="flex-1 p-2"
-      >
-      <select
-        v-model="selectedGenre"
-        class="p-2"
-      >
-        <option value="">
-          All genres
-        </option>
-        <option
-          v-for="genre in genres"
-          :key="genre"
-          :value="genre"
+      <div class="flex gap-4 mb-4">
+        <input
+          v-model="searchQuery"
+          placeholder="Search by title or author"
+          class="flex-1 p-2"
         >
-          {{ genre }}
-        </option>
-      </select>
-      <select
-        v-model="sortKey"
-        class="p-2"
-      >
-        <option value="title">
-          Title
-        </option>
-        <option value="author">
-          Author
-        </option>
-      </select>
-    </div>
+        <select
+          v-model="selectedGenre"
+          class="p-2"
+        >
+          <option value="">
+            All genres
+          </option>
+          <option
+            v-for="genre in genres"
+            :key="genre"
+            :value="genre"
+          >
+            {{ genre }}
+          </option>
+        </select>
+        <select
+          v-model="sortKey"
+          class="p-2"
+        >
+          <option value="title">
+            Title
+          </option>
+          <option value="author">
+            Author
+          </option>
+        </select>
+      </div>
 
-    <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
-      <BookCard
-        v-for="book in sortedBooks"
-        :key="book.id"
-        :book="book"
-      />
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+        <BookCard
+          v-for="book in sortedBooks"
+          :key="book.id"
+          :book="book"
+        />
+      </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.bookshelf {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 148px,
+    #d2b48c 148px,
+    #d2b48c 150px
+  );
+  background-size: 100% 150px;
+}
+</style>

--- a/tests/components/BookCard.spec.ts
+++ b/tests/components/BookCard.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BookCard from '../../components/BookCard.vue';
+import type { Book } from '../../data/books';
+
+const book: Book = {
+  id: 1,
+  title: 'Test Book',
+  author: 'Tester',
+  genre: 'Fiction',
+  cover: 'https://placehold.co/150x200',
+};
+
+describe('BookCard', () => {
+  it('renders title and author', () => {
+    const wrapper = mount(BookCard, { props: { book } });
+    expect(wrapper.text()).toContain('Test Book');
+    expect(wrapper.text()).toContain('Tester');
+  });
+});

--- a/tests/data.spec.ts
+++ b/tests/data.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { sampleBooks } from '../data/books';
+
+describe('sampleBooks', () => {
+  it('contains 10 books', () => {
+    expect(sampleBooks).toHaveLength(10);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import vue from '@vitejs/plugin-vue';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '~': root,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- enhance book display page with library styling and book shelves
- move sample book data into `data/books.ts`
- expand sample book list
- use shared `Book` type in `BookCard`

## Testing
- `npx nuxi prepare`
- `npm run lint -- --fix`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871282b61e0832fbaf1611853a7d5ba