### PR TITLE
Set up Docker Compose with MySQL and Node.js

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:24
+
+# Install basic development tools
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    git \
+    vim \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install MySQL client
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    default-mysql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the default shell to bash
+ENV SHELL /bin/bash
+
+# Create workspace directory
+WORKDIR /workspaces/bookshelf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,16 @@
 {
   "name": "Bookshelf DevContainer",
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
-  },
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/bookshelf",
   "postCreateCommand": "npm install",
-  "forwardPorts": [3000],
+  "forwardPorts": [3000, 3306],
   "portsAttributes": {
     "3000": {
       "label": "Nuxt"
+    },
+    "3306": {
+      "label": "MySQL"
     }
   },
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    network_mode: service:db
+    environment:
+      - DB_HOST=localhost
+      - DB_PORT=3306
+      - DB_USER=bookshelf
+      - DB_PASSWORD=bookshelf
+      - DB_NAME=bookshelf
+      - NODE_ENV=development
+
+  db:
+    image: mysql:8.4
+    restart: unless-stopped
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: bookshelf
+      MYSQL_USER: bookshelf
+      MYSQL_PASSWORD: bookshelf
+    ports:
+      - "3306:3306"
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
- Add docker-compose.yml with MySQL 8.4 and Node.js 24 services
- Create Dockerfile for Node.js 24 development environment
- Update devcontainer.json to use docker-compose configuration
- Configure MySQL database (bookshelf) with user credentials
- Add MySQL port forwarding (3306) alongside Nuxt (3000)