### PR TITLE
fix: Add ESM compatibility for __dirname in database setup script

### DIFF
--- a/database/setup.ts
+++ b/database/setup.ts
@@ -1,6 +1,10 @@
 import mysql from 'mysql2/promise';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 async function setupDatabase() {
   const connection = await mysql.createConnection({


### PR DESCRIPTION
Use fileURLToPath and import.meta.url to define __dirname in ESM context